### PR TITLE
Update boost source to an URL that works

### DIFF
--- a/org.freecad.FreeCAD.yaml
+++ b/org.freecad.FreeCAD.yaml
@@ -200,7 +200,7 @@ modules:
       - ./b2 install -j $FLATPAK_BUILDER_N_JOBS cxxflags="-I/usr/include/python3.11" 
     sources:
       - type: archive
-        url: https://boostorg.jfrog.io/artifactory/main/release/1.84.0/source/boost_1_84_0.tar.bz2
+        url: https://archives.boost.io/release/1.84.0/source/boost_1_84_0.tar.bz2
         sha256: cc4b893acf645c9d4b698e9a0f08ca8846aa5d6c68275c14c3e7949c24109454
 
   - name: coin


### PR DESCRIPTION
the other failed. This is the official download link.