### PR TITLE
[beta] Drop backported functools lru_cache

### DIFF
--- a/org.freecad.FreeCAD.yaml
+++ b/org.freecad.FreeCAD.yaml
@@ -334,15 +334,6 @@ modules:
         url: https://files.pythonhosted.org/packages/cd/66/fa77e809b7cb1c2e14b48c7fc8a8cd657a27f4f9abb848df0c967b6e4e11/setuptools_scm-4.1.2.tar.gz
         sha256: a8994582e716ec690f33fec70cca0f85bd23ec974e3f783233e4879090a7faa8
 
-  - name: backports_functools_lru_cache
-    buildsystem: simple
-    build-commands:
-      - python3 setup.py install --prefix=/app --root=/
-    sources:
-      - type: archive
-        url: https://files.pythonhosted.org/packages/ad/2e/aa84668861c3de458c5bcbfb9813f0e26434e2232d3e294469e96efac884/backports.functools_lru_cache-1.6.1.tar.gz
-        sha256: 8fde5f188da2d593bd5bc0be98d9abc46c95bb8a9dde93429570192ee6cc2d4a
-
   - python3-cycler.json
 
   - name: python-dateutil


### PR DESCRIPTION
Firstly, functools.lru_cache was added in Python 3.2 (with some API enhancements included in 3.3). Build already requires Python 3.12.

Secondly, lru_cache is only imported from the Crowdin import script which shouldn't even be called from application itself.


(this is a cherry-pick from master)