### PR TITLE
Issue 11

### DIFF
--- a/org.freecad.FreeCAD.yaml
+++ b/org.freecad.FreeCAD.yaml
@@ -481,6 +481,8 @@ modules:
         sha256: 618da8a8b3f5be46b4f0a47a1efb3c9e6c03d6aab0f5531d56d355d32701d79f
   - name: nlohmann-json
     buildsystem: cmake-ninja
+    config-opts:
+      - -DJSON_BuildTests=OFF
     sources:
       - type: archive
         url: https://github.com/nlohmann/json/archive/refs/tags/v3.12.0.tar.gz

--- a/org.freecad.FreeCAD.yaml
+++ b/org.freecad.FreeCAD.yaml
@@ -186,6 +186,7 @@ modules:
     config-opts:
       - -DCMAKE_BUILD_TYPE=Release
       - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+      - -DZLIB_RUNTIME_LINKING=OFF
     cleanup:
       - /bin
     sources:


### PR DESCRIPTION
coin: Fix build for wrz support
    
The broken code in coin expect bare .so for dynamic loading.
So build with dynamic linking
    
Close #11

json: don't build tests
    
This shorten the module build by a lot
